### PR TITLE
mbedtls: Make rc4, camellia, blowfish cipher checks optional

### DIFF
--- a/m4/mbedtls.m4
+++ b/m4/mbedtls.m4
@@ -57,7 +57,7 @@ AC_DEFUN([ss_MBEDTLS],
       ]]
     )],
     [AC_MSG_RESULT([ok])],
-    [AC_MSG_ERROR([MBEDTLS_ARC4_C required])]
+    [AC_MSG_WARN([We will continue without ARC4 stream cipher support, MBEDTLS_ARC4_C required])]
   )
 
   AC_MSG_CHECKING([whether mbedtls supports the Blowfish block cipher or not])
@@ -73,7 +73,7 @@ AC_DEFUN([ss_MBEDTLS],
       ]]
     )],
     [AC_MSG_RESULT([ok])],
-    [AC_MSG_ERROR([MBEDTLS_BLOWFISH_C required])]
+    [AC_MSG_WARN([We will continue without Blowfish block cipher support, MBEDTLS_BLOWFISH_C required])]
   )
 
   AC_MSG_CHECKING([whether mbedtls supports the Camellia block cipher or not])
@@ -89,6 +89,6 @@ AC_DEFUN([ss_MBEDTLS],
       ]]
     )],
     [AC_MSG_RESULT([ok])],
-    [AC_MSG_ERROR([MBEDTLS_CAMELLIA_C required])]
+    [AC_MSG_WARN([We will continue without Camellia block cipher support, MBEDTLS_CAMELLIA_C required])]
   )
 ])


### PR DESCRIPTION
Per Felix Fietkau's request in https://github.com/lede-project/source/pull/657

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>